### PR TITLE
fix(worker,llm): correct cancel-during-ingestion status and harden enrichment parsing

### DIFF
--- a/src/autoapply_agent/services/llm_enrichment.py
+++ b/src/autoapply_agent/services/llm_enrichment.py
@@ -59,7 +59,7 @@ class LLMEnrichmentService:
             if self._settings.llm_provider == "gpt":
                 return await self._call_gpt(prompt)
             return None
-        except (httpx.HTTPError, ValueError, KeyError, TypeError):
+        except (httpx.HTTPError, ValueError, KeyError, TypeError, IndexError):
             return None
 
     @staticmethod

--- a/src/autoapply_agent/services/worker.py
+++ b/src/autoapply_agent/services/worker.py
@@ -148,6 +148,9 @@ class InProcessWorker:
 
                     await self._process_source(session, run, source_config)
 
+                if run.status == RunStatus.CANCELLED.value:
+                    return
+
                 run.status = RunStatus.COMPLETED.value
                 run.finished_at = utc_now()
                 await append_run_event(

--- a/tests/integration/test_run_cancel_during_processing.py
+++ b/tests/integration/test_run_cancel_during_processing.py
@@ -1,0 +1,110 @@
+"""Regression test: cancellation during active job ingestion must persist as cancelled."""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any
+
+from fastapi.testclient import TestClient
+
+from autoapply_agent.adapters.base import JobCandidate
+from autoapply_agent.adapters.greenhouse import GreenhouseAdapter
+from autoapply_agent.core.config import Settings
+from autoapply_agent.main import create_app
+from autoapply_agent.services.worker import InProcessWorker
+
+if TYPE_CHECKING:
+    from _pytest.capture import CaptureFixture
+    from _pytest.fixtures import FixtureRequest
+    from _pytest.logging import LogCaptureFixture
+    from _pytest.monkeypatch import MonkeyPatch
+    from pytest_mock.plugin import MockerFixture
+
+# Shared flag flipped to True once the adapter has fetched jobs, i.e. once the
+# worker is inside the per-job loop of the only source.
+_FETCH_STATE: dict[str, bool] = {"fetched": False}
+
+
+async def _fake_fetch_then_arm_cancel(
+    self: GreenhouseAdapter,
+    base_url: str,
+    timeout_seconds: float,
+    max_jobs: int,
+) -> list[JobCandidate]:
+    """Return one job and arm cancellation for the subsequent job-loop check."""
+    del self, timeout_seconds, max_jobs
+    _FETCH_STATE["fetched"] = True
+    return [
+        JobCandidate(
+            external_id="int-cancel-001",
+            title="Python Backend Engineer",
+            location="Remote",
+            company="example.com",
+            url=f"{base_url.rstrip('/')}/jobs/int-cancel-001",
+            raw={"fixture": "cancel"},
+        )
+    ]
+
+
+async def _cancel_after_fetch(self: InProcessWorker, session: Any, run_id: str) -> bool:
+    """Report cancellation only after the source's jobs have been fetched.
+
+    This makes the source-loop check (before fetch) return ``False`` so the
+    source is processed, then makes the per-job check (after fetch) return
+    ``True`` so cancellation fires while ingesting the only source's jobs.
+    """
+    del self, session, run_id
+    return _FETCH_STATE["fetched"]
+
+
+def test_cancel_during_last_source_persists_cancelled(
+    sqlite_database_url: str,
+    monkeypatch: MockerFixture,
+) -> None:
+    """Cancelling while ingesting the only source must end as cancelled, not completed."""
+    _FETCH_STATE["fetched"] = False
+    monkeypatch.setattr(GreenhouseAdapter, "fetch_jobs", _fake_fetch_then_arm_cancel)
+    monkeypatch.setattr(InProcessWorker, "_is_cancel_requested", _cancel_after_fetch)
+
+    settings = Settings(
+        APP_NAME="autoapply-cancel-test",
+        DATABASE_URL=sqlite_database_url,
+        WORKER_POLL_INTERVAL_SECONDS=0.05,
+        HTTP_TIMEOUT_SECONDS=0.5,
+        MAX_JOBS_PER_SOURCE=5,
+        HTTP_USER_AGENT="integration-test-agent",
+        ENABLE_WORKER=True,
+        ENVIRONMENT="test",
+    )
+    app = create_app(settings)
+    with TestClient(app) as client:
+        source_response = client.post(
+            "/source-configs",
+            json={
+                "name": "integration-greenhouse-cancel",
+                "source_type": "greenhouse",
+                "base_url": "https://boards.greenhouse.io/embed/job_board?for=example",
+            },
+        )
+        assert source_response.status_code == 201
+
+        run_response = client.post("/runs", json={"query": "python backend"})
+        assert run_response.status_code == 201
+        run_id = run_response.json()["id"]
+
+        status_payload: dict[str, Any] = {}
+        for _ in range(60):
+            status_response = client.get(f"/runs/{run_id}")
+            assert status_response.status_code == 200
+            status_payload = status_response.json()
+            if status_payload["status"] in {"completed", "failed", "cancelled"}:
+                break
+            time.sleep(0.05)
+
+        assert status_payload["status"] == "cancelled"
+
+        events_response = client.get(f"/runs/{run_id}/events")
+        assert events_response.status_code == 200
+        event_types = [entry["event_type"] for entry in events_response.json()]
+        assert "run.cancelled" in event_types
+        assert "run.completed" not in event_types

--- a/tests/unit/test_llm_enrichment_malformed.py
+++ b/tests/unit/test_llm_enrichment_malformed.py
@@ -1,0 +1,127 @@
+"""Regression tests for LLM enrichment resilience to malformed 200 responses."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+from autoapply_agent.adapters.base import JobCandidate
+from autoapply_agent.core.config import Settings
+from autoapply_agent.services import llm_enrichment
+from autoapply_agent.services.llm_enrichment import LLMEnrichmentService
+
+if TYPE_CHECKING:
+    from _pytest.capture import CaptureFixture
+    from _pytest.fixtures import FixtureRequest
+    from _pytest.logging import LogCaptureFixture
+    from _pytest.monkeypatch import MonkeyPatch
+    from pytest_mock.plugin import MockerFixture
+
+
+class _FakeResponse:
+    """Minimal stand-in for an httpx.Response returning a fixed JSON body."""
+
+    def __init__(self, payload: dict[str, Any]) -> None:
+        """Store the JSON payload to return.
+
+        Args:
+            payload: Decoded JSON body to return from ``json()``.
+        """
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        """No-op: emulate a successful 2xx response."""
+
+    def json(self) -> dict[str, Any]:
+        """Return the canned JSON payload."""
+        return self._payload
+
+
+class _FakeAsyncClient:
+    """Minimal async context-manager stand-in for httpx.AsyncClient."""
+
+    def __init__(self, payload: dict[str, Any]) -> None:
+        """Store the payload to hand back from ``post``.
+
+        Args:
+            payload: Decoded JSON body to return from the POST call.
+        """
+        self._payload = payload
+
+    async def __aenter__(self) -> _FakeAsyncClient:
+        """Enter the async context."""
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> bool:
+        """Exit the async context without suppressing exceptions."""
+        return False
+
+    async def post(self, *args: Any, **kwargs: Any) -> _FakeResponse:
+        """Return a fake successful response with the canned payload."""
+        return _FakeResponse(self._payload)
+
+
+def _candidate() -> JobCandidate:
+    """Build a deterministic job candidate for enrichment tests."""
+    return JobCandidate(
+        external_id="job-1",
+        title="ML Engineer",
+        location="Remote",
+        company="example.ai",
+        url="https://example.ai/jobs/1",
+        raw=None,
+    )
+
+
+def test_gemini_empty_candidates_returns_none(monkeypatch: MonkeyPatch) -> None:
+    """A 200 response with an empty ``candidates`` array must fall back to None."""
+    settings = Settings(
+        APP_NAME="test",
+        DATABASE_URL="sqlite+aiosqlite:///./test.db",
+        LLM_ENABLE_ENRICHMENT=True,
+        LLM_PROVIDER="gemini",
+        GEMINI_API_KEY="dummy-key",
+    )
+    monkeypatch.setattr(
+        llm_enrichment.httpx,
+        "AsyncClient",
+        lambda *args, **kwargs: _FakeAsyncClient({"candidates": []}),
+    )
+    service = LLMEnrichmentService(settings)
+
+    result = asyncio.run(
+        service.enrich_job_decision(
+            job_candidate=_candidate(),
+            query="machine learning platform",
+            deterministic_rationale=["deterministic baseline"],
+        )
+    )
+
+    assert result is None
+
+
+def test_openai_compatible_empty_choices_returns_none(monkeypatch: MonkeyPatch) -> None:
+    """A 200 response with an empty ``choices`` array must fall back to None."""
+    settings = Settings(
+        APP_NAME="test",
+        DATABASE_URL="sqlite+aiosqlite:///./test.db",
+        LLM_ENABLE_ENRICHMENT=True,
+        LLM_PROVIDER="gpt",
+        OPENAI_API_KEY="dummy-key",
+    )
+    monkeypatch.setattr(
+        llm_enrichment.httpx,
+        "AsyncClient",
+        lambda *args, **kwargs: _FakeAsyncClient({"choices": []}),
+    )
+    service = LLMEnrichmentService(settings)
+
+    result = asyncio.run(
+        service.enrich_job_decision(
+            job_candidate=_candidate(),
+            query="platform engineering",
+            deterministic_rationale=["deterministic baseline"],
+        )
+    )
+
+    assert result is None


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes two latent run-lifecycle correctness bugs found during the daily audit. Both are deterministic and covered by new regression tests (each fails before the fix).

### 1. Cancellation during ingestion of the only/last source was lost
`InProcessWorker._process_source()` marks a run **cancelled** and returns when cancellation is requested mid job-loop, but `_execute_run()` then **unconditionally** set the status to `COMPLETED` after the source loop finished. So cancelling during the only source (or the last source) produced a `completed` run and an event log containing both `run.cancelled` and `run.completed`.

Fix: after the source loop, return early if the run is already `CANCELLED` before marking it completed. (Cancellation *between* sources was already handled by the loop's pre-source check.)

### 2. LLM enrichment crashed the whole run on an empty provider array
`enrich_job_decision()` is documented to fail open (return `None`), but the Gemini/OpenAI-compatible parsers index `candidates[0]` / `choices[0]` without a length check. A `200 OK` with `{"candidates": []}` or `{"choices": []}` raised `IndexError`, which was **not** in the caught exception tuple, so it propagated and failed the entire run instead of falling back to the deterministic baseline.

Fix: add `IndexError` to the caught exceptions in `enrich_job_decision()`.

## Changes
- `src/autoapply_agent/services/worker.py`: guard against overwriting a cancelled run with `completed`.
- `src/autoapply_agent/services/llm_enrichment.py`: catch `IndexError` so malformed-but-200 responses fall back to `None`.
- `tests/integration/test_run_cancel_during_processing.py` (new): cancels while ingesting the only source; asserts final status `cancelled`, `run.cancelled` present and `run.completed` absent.
- `tests/unit/test_llm_enrichment_malformed.py` (new): empty `candidates`/`choices` arrays return `None` with no exception.

## Validation
In the repo `.venv` (Python 3.12, `uv sync --extra dev --frozen`):
- `ruff check .` — passed
- `ruff format --check .` — passed
- `mypy` — success, 30 source files
- `pytest -q` — 15 passed (was 12; +3 new tests)

Confirmed all three new tests fail on `main` before the fixes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97378c9f-721e-4ee3-83c6-94b82b3122c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97378c9f-721e-4ee3-83c6-94b82b3122c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

